### PR TITLE
Fix Normalized enrichments scores and repo improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,8 @@ name: Rust
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - '*'
   pull_request:
     branches: [ "master" ]
 
@@ -20,3 +22,35 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --all --verbose
+
+  release:
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: build
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Install cargo binstall
+        uses: cargo-bins/cargo-binstall@main
+      - name: cargo-release Cache
+        id: cargo_release_cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/cargo-release
+          key: ${{ runner.os }}-cargo-release
+      - name: Install cargo release
+        if: steps.cargo_release_cache.outputs.cache-hit != 'true'
+        run: cargo binstall cargo-release
+      - name: cargo login
+        run: cargo login
+      - name: "cargo release publish"
+        run: |-
+          cargo release \
+            publish \
+            --workspace \
+            --all-features \
+            --allow-branch HEAD \
+            --no-confirm \
+            --no-verify \
+            --execute

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "webgestalt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "clap",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "webgestalt_lib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ahash",
  "csv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +400,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -634,11 +650,10 @@ dependencies = [
 [[package]]
 name = "webgestalt_lib"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c001c59ee0aee8eba0a7714e4fa36b6e4ba466be9f48f261d2fa5491db6022a7"
 dependencies = [
  "ahash",
  "csv",
+ "pretty_assertions",
  "rand",
  "rayon",
  "serde",
@@ -720,6 +735,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,12 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,16 +394,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "pretty_assertions"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
-dependencies = [
- "diff",
- "yansi",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -650,10 +634,11 @@ dependencies = [
 [[package]]
 name = "webgestalt_lib"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c001c59ee0aee8eba0a7714e4fa36b6e4ba466be9f48f261d2fa5491db6022a7"
 dependencies = [
  "ahash",
  "csv",
- "pretty_assertions",
  "rand",
  "rayon",
  "serde",
@@ -735,12 +720,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/bzhanglab/webgestalt_rust"
 bincode = "1.3.3"
 clap = { version = "4.4.15", features = ["derive"] }
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
-webgestalt_lib = { version = "0.1.0" }
+webgestalt_lib = { path = "webgestalt_lib" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "webgestalt"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["John Elizarraras"]
 edition = "2021"
 rust-version = "1.63.0"
@@ -16,7 +16,7 @@ repository = "https://github.com/bzhanglab/webgestalt_rust"
 bincode = "1.3.3"
 clap = { version = "4.4.15", features = ["derive"] }
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
-webgestalt_lib = { path = "webgestalt_lib" }
+webgestalt_lib = { version = "0.1.0", path = "webgestalt_lib" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/bzhanglab/webgestalt_rust"
 bincode = "1.3.3"
 clap = { version = "4.4.15", features = ["derive"] }
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
-webgestalt_lib = { path = "webgestalt_lib" }
+webgestalt_lib = { version = "0.1.0" }
 
 [profile.release]
 opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,10 +123,10 @@ fn main() {
                     "webgestalt_lib/data/test.rnk".to_owned(),
                 );
                 let gmt = webgestalt_lib::readers::read_gmt_file(
-                    "webgestalt_lib/data/test.gmt".to_owned(),
+                    "webgestalt_lib/data/ktest.gmt".to_owned(),
                 );
                 let start = Instant::now();
-                webgestalt_lib::methods::gsea::gsea(
+                let res = webgestalt_lib::methods::gsea::gsea(
                     gene_list.unwrap(),
                     gmt.unwrap(),
                     GSEAConfig::default(),
@@ -137,7 +137,7 @@ fn main() {
             }
             Some(ExampleOptions::Ora) => {
                 let (gmt, gene_list, reference) = webgestalt_lib::readers::read_ora_files(
-                    "webgestalt_lib/data/test.gmt".to_owned(),
+                    "webgestalt_lib/data/ktest.gmt".to_owned(),
                     "webgestalt_lib/data/genelist.txt".to_owned(),
                     "webgestalt_lib/data/reference.txt".to_owned(),
                 );

--- a/webgestalt_lib/Cargo.toml
+++ b/webgestalt_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webgestalt_lib"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["John Elizarraras"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/webgestalt_lib/src/methods/gsea.rs
+++ b/webgestalt_lib/src/methods/gsea.rs
@@ -92,6 +92,7 @@ impl RankListItem {
 /// Run GSEA for one analyte set.
 ///
 /// Returns a [`GSEAResult`], which does not have FDR.
+///
 /// # Parameters
 ///
 /// - `analytes` - Vector containing the names of the analytes
@@ -200,8 +201,16 @@ fn analyte_set_p(
             .collect();
         let up_len = up.len();
         let down_len = down.len();
-        let up_avg: f64 = up.par_iter().sum::<f64>() / (up_len as f64 + 0.000001) + 0.000001; // up average
-        let down_avg: f64 = down.par_iter().sum::<f64>() / (down_len as f64 + 0.000001) - 0.000001; // down average
+        let up_avg: f64 = if up.is_empty() {
+            0.000001
+        } else {
+            up.par_iter().sum::<f64>() / (up_len as f64 + 0.000001) - 0.000001
+        }; // up average
+        let down_avg: f64 = if down.is_empty() {
+            -0.000001
+        } else {
+            down.par_iter().sum::<f64>() / (down_len as f64 + 0.000001) - 0.000001
+        }; // down average
         let mut nes_es: Vec<f64> = up.par_iter().map(|x| x / up_avg).collect(); // get all normalized scores for up
         nes_es.extend(down.par_iter().map(|x| -x / down_avg).collect::<Vec<f64>>()); // extend with down scores
         let norm_es: f64 = if real_es >= 0_f64 {

--- a/webgestalt_lib/src/methods/gsea.rs
+++ b/webgestalt_lib/src/methods/gsea.rs
@@ -196,7 +196,7 @@ fn analyte_set_p(
             .collect();
         let down: Vec<f64> = es_iter // down scores
             .par_iter()
-            .filter(|&x| *x < 0_f64)
+            .filter(|&x| *x <= 0_f64)
             .copied()
             .collect();
         let up_len = up.len();
@@ -204,18 +204,24 @@ fn analyte_set_p(
         let up_avg: f64 = if up.is_empty() {
             0.000001
         } else {
-            up.par_iter().sum::<f64>() / (up_len as f64 + 0.000001) - 0.000001
+            up.par_iter().sum::<f64>() / (up_len as f64 + 0.000001) + 0.000001
         }; // up average
         let down_avg: f64 = if down.is_empty() {
             -0.000001
         } else {
-            down.par_iter().sum::<f64>() / (down_len as f64 + 0.000001) - 0.000001
+            down.par_iter().sum::<f64>() / (down_len as f64 - 0.000001) - 0.000001
         }; // down average
         let mut nes_es: Vec<f64> = up.par_iter().map(|x| x / up_avg).collect(); // get all normalized scores for up
         nes_es.extend(down.par_iter().map(|x| -x / down_avg).collect::<Vec<f64>>()); // extend with down scores
         let norm_es: f64 = if real_es >= 0_f64 {
             // get normalized score for the real run
-            real_es / up_avg
+            if up.is_empty() {
+                0.0
+            } else {
+                real_es / up_avg
+            }
+        } else if down.is_empty() {
+            0.0
         } else {
             -real_es / down_avg
         };

--- a/webgestalt_lib/src/readers.rs
+++ b/webgestalt_lib/src/readers.rs
@@ -34,7 +34,7 @@ pub fn read_gmt_file(path: String) -> Result<Vec<Item>, Box<std::io::Error>> {
             .iter()
             .map(|x| x.to_string())
             .collect::<Vec<String>>();
-        let id = result.get(0).unwrap().to_owned();
+        let id = result.first().unwrap().to_owned();
         let url = result.get(1).unwrap().to_owned();
         let parts = result[2..].to_vec();
         let item = Item { id, url, parts };
@@ -57,7 +57,7 @@ pub fn read_rank_file(path: String) -> Result<Vec<RankListItem>, Box<std::io::Er
             .iter()
             .map(|x| x.to_string())
             .collect::<Vec<String>>();
-        let phenotype = result.get(0).unwrap().to_owned();
+        let phenotype = result.first().unwrap().to_owned();
         let rank = result.get(1).unwrap().to_owned().parse::<f64>().unwrap();
         let item = RankListItem {
             analyte: phenotype,
@@ -101,7 +101,7 @@ pub fn read_ora_files(
             .iter()
             .map(|x| x.to_string())
             .collect::<Vec<String>>();
-        let id = result.get(0).unwrap().to_owned();
+        let id = result.first().unwrap().to_owned();
         let url = result.get(1).unwrap().to_owned();
         let parts = result[2..].to_vec();
         for analyte in parts.clone().into_iter() {

--- a/webgestalt_lib/src/readers.rs
+++ b/webgestalt_lib/src/readers.rs
@@ -7,6 +7,19 @@ use std::{
 };
 use utils::Item;
 
+/// Read GMT file from specified path. For format description, see [broadinstitute.org](https://software.broadinstitute.org/cancer/software/gsea/wiki/index.php/Data_formats#GMT:_Gene_Matrix_Transposed_file_format_.28.2A.gmt.29)
+///
+/// # Parameters
+///
+/// - `path` - A [`String`] of the path of the GMT to read.
+///
+/// # Panics
+///
+/// Panics if there is not file at `path`.
+///
+/// # Returns
+///
+/// If result is `Ok`, returns a [`Vec<Item>`] containing the elements of the GMT
 pub fn read_gmt_file(path: String) -> Result<Vec<Item>, Box<std::io::Error>> {
     let file = File::open(path)?;
     let mut rdr = csv::ReaderBuilder::new()


### PR DESCRIPTION
This release fixes a bug for cases where the GSEA enrichment score for a gene set did not share a sign with any of the random permutations.

## Previous behavior

Example case: the enrichment score for set $S$ is a negative value. The 1000 permutations had all positive enrichment scores. To calculate the normalized enrichment score (NES), you divide the real score by the average of the random scores that are of the same sign (in this example the average of the negative scores). Since there are no negative random scores, the average would be 0.

To avoid dividing by 0, old WebGestaltR would add 0.000001 to every average. In this example, this would result in multiply the enrichment score by $10^{-5}$.

The old R package would set the NES to 0 if this happened, but this step was missed in the rust implementation, resulting in a high NES.

## New behavior

To avoid this abnormally high normalized score, if there are no permutations with a matched sign, the normalized score is set to 0. This is the same behavior as the original R package.