### PR TITLE
fix(lib): fix error caused by seeds not found in network

### DIFF
--- a/webgestalt_lib/src/methods/nta.rs
+++ b/webgestalt_lib/src/methods/nta.rs
@@ -141,7 +141,7 @@ pub fn process_nta(config: NTAConfig) -> Vec<(String, f64)> {
     let node_indices: Vec<usize> = config
         .seeds
         .iter()
-        .map(|seed| *node_map.get(seed).unwrap())
+        .filter_map(|seed| node_map.get(seed).cloned())
         .collect();
     let walk_res = random_walk_probability(
         &graph,


### PR DESCRIPTION
Filters out seeds not found in network. The R package does this filter so this was not initially
implemented in the library.
