### PR TITLE
FDR greater than 1.0 set to 1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "webgestalt"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bincode",
  "clap",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "webgestalt_lib"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ahash",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "webgestalt"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["John Elizarraras"]
 edition = "2021"
 rust-version = "1.63.0"
@@ -17,7 +17,7 @@ bincode = "1.3.3"
 clap = { version = "4.4.15", features = ["derive"] }
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
 serde_json = "1.0.116"
-webgestalt_lib = { version = "0.3.1", path = "webgestalt_lib" }
+webgestalt_lib = { version = "0.3.2", path = "webgestalt_lib" }
 
 [profile.release]
 opt-level = 3

--- a/webgestalt_lib/Cargo.toml
+++ b/webgestalt_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webgestalt_lib"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["John Elizarraras"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/webgestalt_lib/src/methods/gsea.rs
+++ b/webgestalt_lib/src/methods/gsea.rs
@@ -379,6 +379,13 @@ pub fn gsea(
             .filter(|&x| x.abs() >= nes_abs)
             .count() as f64;
         let fdr: f64 = (top_val * bottom_len) / (bottom_val * top_len); // get FDR value
+        let fdr = if fdr.is_nan() {
+            0.0
+        } else if fdr > 1.0 {
+            1.0
+        } else {
+            fdr
+        };
         final_gsea.push(item.add_fdr(fdr));
     }
     final_gsea


### PR DESCRIPTION
For FDR > 1, `gsea` will set the value back to 1.0. This copies the behavior from the original R package. Fixes #27.